### PR TITLE
models.workflow.delete: make uuid mandatory

### DIFF
--- a/invenio_workflows/models.py
+++ b/invenio_workflows/models.py
@@ -89,10 +89,10 @@ class Workflow(db.Model):
                 str(self.id_user), str(self.status))
 
     @classmethod
-    def delete(cls, uuid=None):
+    def delete(cls, uuid):
         """Delete a workflow."""
-        uuid = uuid or cls.uuid
-        db.session.delete(Workflow.query.get(uuid))
+        to_delete = Workflow.query.get(uuid)
+        db.session.delete(to_delete)
 
     def save(self, status=None):
         """Save object to persistent storage."""


### PR DESCRIPTION
It makes no sense to have a classmethod trying to access an instance
level property (that never worked) so simplifying the method to use
always the passed uuid.

Signed-off-by: David Caro <david@dcaro.es>