### PR TITLE
models: remove extra space for flake8 compliance

### DIFF
--- a/invenio_workflows/models.py
+++ b/invenio_workflows/models.py
@@ -85,7 +85,7 @@ class Workflow(db.Model):
         """Represent a workflow object."""
         return "<Workflow(name: %s, cre: %s, mod: %s," \
                "id_user: %s, status: %s)>" % \
-               (str(self.name),  str(self.created), str(self.modified),
+               (str(self.name), str(self.created), str(self.modified),
                 str(self.id_user), str(self.status))
 
     @classmethod


### PR DESCRIPTION
As https://github.com/inveniosoftware-contrib/invenio-workflows/pull/47 has shown, the build is broken. This PR fixes it.